### PR TITLE
locking sqlalchemy to specific version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ connexion~=2.7.0
 flask~=1.1.2
 flask-sqlalchemy
 jsonschema~=3.2.0
-sqlalchemy
+sqlalchemy~=1.4.0
 swagger-ui-bundle
 PyJWT~=1.7.1
 markupsafe==2.0.1


### PR DESCRIPTION
sqlalchemy latest has breaking changes that causes VAmPI to not start.

By locking its version to 1.4.0 we can get the containers up and running as usual